### PR TITLE
migrations: add question_order to survey_question_answers, remove nul…

### DIFF
--- a/db/migrate/20200106235748_add_question_order_to_survey_question_answers.rb
+++ b/db/migrate/20200106235748_add_question_order_to_survey_question_answers.rb
@@ -1,0 +1,5 @@
+class AddQuestionOrderToSurveyQuestionAnswers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :survey_question_answers, :question_order, :integer
+  end
+end

--- a/db/migrate/20200107000032_add_change_column_null_to_question_option_id.rb
+++ b/db/migrate/20200107000032_add_change_column_null_to_question_option_id.rb
@@ -1,0 +1,5 @@
+class AddChangeColumnNullToQuestionOptionId < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :survey_question_answers, :question_option_id, true
+  end
+end


### PR DESCRIPTION
migrations: add question_order to survey_question_answers, remove null constraint on question_option_id

once merged and pulled, run:
rake db:drop db:create db:migrate db:seed